### PR TITLE
Move test file into t directory.

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,5 +1,5 @@
 # Before `make install' is performed this script should be runnable with
-# `make test'. After `make install' it should work as `perl test.pl'
+# `make test'. After `make install' it should work as `perl t/basic.t'
 
 ######################### We start with some black magic to print on failure.
 


### PR DESCRIPTION
Moves test.pl to t/basic.t, to match the common convention. 'make test' should still act as you expect.

Fixes CPANTS warning about the old-style test.pl: http://cpants.cpanauthors.org/dist/Win32-Process
