### PR TITLE
Fix Win32::Process::KillProcess() with VC9 (RT#46688)

### DIFF
--- a/Process.xs
+++ b/Process.xs
@@ -444,7 +444,12 @@ KillProcess(pid, exitcode)
     unsigned int exitcode
 CODE:
     {
-	HANDLE ph = OpenProcess(PROCESS_ALL_ACCESS, 0, pid);
+	HANDLE ph = OpenProcess(PROCESS_DUP_HANDLE        |
+	                        PROCESS_QUERY_INFORMATION |
+	                        PROCESS_SET_INFORMATION   |
+	                        PROCESS_TERMINATE         |
+	                        SYNCHRONIZE,
+	                        0, pid);
 	if (ph) {
 	    RETVAL = TerminateProcess(ph, exitcode);
 	    if (RETVAL)


### PR DESCRIPTION
This applies a patch submitted in [https://rt.cpan.org/Ticket/Display.html?id=46688](RT#46688)
