### PR TITLE
Allow "appname" and "cmdline" parameters to Create() to be NULL

### DIFF
--- a/Process.pm
+++ b/Process.pm
@@ -104,13 +104,32 @@ Creates a new process.
     Args:
 
 	$obj		container for process object
-	$appname	full path name of executable module
-	$cmdline	command line args
+	$appname	full path name of executable module (can be 'undef')
+	$cmdline	command line args (can be 'undef')
 	$iflags		flag: inherit calling processes handles or not
 	$cflags		flags for creation (see exported vars below)
 	$curdir		working dir of new process
 
 Returns non-zero on success, 0 on failure.
+
+$appname can be 'undef' to allow $cmdline to specify the command without
+an absolute path; $ENV{PATH} will be searched to find the executable. eg:
+
+    Win32::Process::Create($ProcessObj,
+                           undef,
+                          "netstat -an",      # finds "netstat.exe" from $ENV{PATH}
+                          0,
+                          NORMAL_PRIORITY_CLASS,
+                          ".");
+
+See Microsoft's CreateProcess() docs for details. For instance, only .exe's will
+be searched; if you are trying to run a .com or .bat, you'll have to specify the
+extension, eg:
+
+    Win32::Process::Create($ProcessObj,
+                           undef,
+                          "tree.com /A /F",
+                          [..]
 
 =item Win32::Process::Open($obj,$pid,$iflags)
 

--- a/Process.xs
+++ b/Process.xs
@@ -294,16 +294,17 @@ PROTOTYPES: DISABLE
 
 
 BOOL
-Create(cP,appname,cmdline,inherit,flags,curdir)
+Create(cP,appname_sv,cmdline_sv,inherit,flags,curdir)
     cProcess *cP = NULL;
-    char *appname
-    char *cmdline
+    SV *appname_sv
+    SV *cmdline_sv
     BOOL inherit
     DWORD flags
     char *curdir
+INIT:
+    char *appname = SvOK(appname_sv) ? SvPV_nolen(appname_sv) : NULL;
+    char *cmdline = SvOK(cmdline_sv) ? SvPV_nolen(cmdline_sv) : NULL;
 CODE:
-    appname = SvOK(ST(1)) ? appname : 0;
-    cmdline = SvOK(ST(2)) ? cmdline : 0;
     RETVAL = Create(cP, appname, cmdline, inherit, flags, curdir);
 OUTPUT:
     cP

--- a/Process.xs
+++ b/Process.xs
@@ -302,6 +302,8 @@ Create(cP,appname,cmdline,inherit,flags,curdir)
     DWORD flags
     char *curdir
 CODE:
+    appname = SvOK(ST(1)) ? appname : 0;
+    cmdline = SvOK(ST(2)) ? cmdline : 0;
     RETVAL = Create(cP, appname, cmdline, inherit, flags, curdir);
 OUTPUT:
     cP


### PR DESCRIPTION
The Win32 CreateProcess call allows the application name or cmdline arguments to be NULL.   Allowing application name to be NULL is the only way to ask Win32 to search the PATH for the executable named in the commandline argument.  This is a very useful behavior and would avoid effort in various modules like Proc::Background to have to resolve the executable name by manually searching the PATH.
